### PR TITLE
fix: incorrect label gets added

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -139,7 +139,9 @@ export default (app: Probot) => {
       ];
 
       const labels = defaultLables
-        .filter((label: string) => metadata.pull_request.title.includes(label))
+        .filter((label: string) =>
+          metadata.pull_request.title.startsWith(label)
+        )
         .map((item) => {
           if (item == "feat") item = "feature";
           return item;


### PR DESCRIPTION
Instead of title includes, we should check startsWith

See the problematic PR which has the incorrect labels

https://github.com/daeuniverse/daed/pull/71