### PR TITLE
feat(handler/push): add instrumentation

### DIFF
--- a/api/mock/telegram.ts
+++ b/api/mock/telegram.ts
@@ -1,7 +1,7 @@
 import { Telegram } from "telegraf";
 import { awesome_sticker } from "../../src/constant";
 
-export class TelegramClient {
+class TelegramClient {
   telegram: Telegram;
 
   constructor() {
@@ -9,23 +9,23 @@ export class TelegramClient {
   }
 
   async sendMsg(msg: string, channels: string[]) {
-    Promise.all(
-      channels.map((chat) => {
+    return await Promise.all(
+      channels.map((chat) =>
         this.telegram.sendMessage(chat, msg, {
           parse_mode: "Markdown",
           disable_web_page_preview: true,
-        });
-      })
+        })
+      )
     );
   }
 }
 
 export default async (req, res) => {
   const tg = new TelegramClient();
-  await tg.sendMsg("hello", [
+  const response = await tg.sendMsg("hello", [
     process.env.TELEGRAM_DAEUNIVERSE_AUDIT_CHANNEL_ID!,
   ]);
   res.statusCode = 200;
   res.setHeader("Content-Type", "application/json");
-  res.json({ result: "ok!" });
+  res.json({ result: "ok!", response });
 };

--- a/api/mock/telegram.ts
+++ b/api/mock/telegram.ts
@@ -2,42 +2,29 @@ import { Telegram } from "telegraf";
 import { awesome_sticker } from "../../src/constant";
 
 export class TelegramClient {
-  chat_ids: string[];
-  token: string;
   telegram: Telegram;
 
   constructor() {
-    this.token = process.env.TELEGRAM_BOT_TOKEN as string;
-    this.chat_ids = [
-      process.env.TELEGRAM_GITHUB_CHANNEL_ID as string,
-      // process.env.TELEGRAM_DAEUNIVERSE_CHANNEL_ID as string,
-    ];
-    this.telegram = new Telegram(this.token);
+    this.telegram = new Telegram(process.env.TELEGRAM_BOT_TOKEN!);
   }
 
-  async sendMsg(msg: string) {
-    var promises = this.chat_ids.map((chat: string) => {
-      return new Promise((resolve, reject) => {
-        try {
-          resolve(
-            this.telegram
-              .sendMessage(chat, msg)
-              .then(() => this.telegram.sendSticker(chat, awesome_sticker))
-          );
-        } catch (err) {
-          console.log(err);
-          reject(err);
-        }
-      });
-    });
-
-    await Promise.all(promises);
+  async sendMsg(msg: string, channels: string[]) {
+    Promise.all(
+      channels.map((chat) => {
+        this.telegram.sendMessage(chat, msg, {
+          parse_mode: "Markdown",
+          disable_web_page_preview: true,
+        });
+      })
+    );
   }
 }
 
 export default async (req, res) => {
   const tg = new TelegramClient();
-  await tg.sendMsg("hello");
+  await tg.sendMsg("hello", [
+    process.env.TELEGRAM_DAEUNIVERSE_AUDIT_CHANNEL_ID!,
+  ]);
   res.statusCode = 200;
   res.setHeader("Content-Type", "application/json");
   res.json({ result: "ok!" });

--- a/mock/telegram_test.ts
+++ b/mock/telegram_test.ts
@@ -1,42 +1,32 @@
 import { Telegram } from "telegraf";
-// import { awesome_sticker } from "../src/constant";
 import dotenv from "dotenv";
 
 class TelegramClient {
-  token: string;
   telegram: Telegram;
 
   constructor() {
-    this.token = process.env.TELEGRAM_BOT_TOKEN as string;
-    this.telegram = new Telegram(this.token);
+    this.telegram = new Telegram(process.env.TELEGRAM_BOT_TOKEN!);
   }
 
   async sendMsg(msg: string, channels: string[]) {
-    var promises = channels.map((chat: string) => {
-      return new Promise((resolve, reject) => {
-        try {
-          resolve(
-            this.telegram.sendMessage(chat, msg, {
-              disable_web_page_preview: true,
-            })
-          );
-        } catch (err) {
-          console.log(err);
-          reject(err);
-        }
-      });
-    });
-
-    await Promise.all(promises);
+    return await Promise.all(
+      channels.map((chat) =>
+        this.telegram.sendMessage(chat, msg, {
+          parse_mode: "Markdown",
+          disable_web_page_preview: true,
+        })
+      )
+    );
   }
 }
 
 const main = async () => {
   dotenv.config({ path: ".env" });
   const tg = new TelegramClient();
-  await tg.sendMsg("nihao!", [
-    process.env.TELEGRAM_DAEUNIVERSE_AUDIT_CHANNEL_ID as string,
+  const response = await tg.sendMsg("nihao!", [
+    process.env.TELEGRAM_INFRA_DEV_CHANNEL_ID as string,
   ]);
+  console.log(response);
 };
 
 main();

--- a/src/events/push.ts
+++ b/src/events/push.ts
@@ -207,9 +207,9 @@ async function handler(
 
               // 1.5 add assignee
               tracer.startActiveSpan(
-                "app.handler.push.daed_sync_upstream.create_pull_request.add_labels",
+                "app.handler.push.daed_sync_upstream.create_pull_request.add_assignee",
                 async (span: Span) => {
-                  span.setAttribute("functionality", "add labels");
+                  span.setAttribute("functionality", "add assignee");
                   // https://octokit.github.io/rest.js/v18#issues-add-assignees
                   context.octokit.issues.addAssignees({
                     owner: metadata.owner,

--- a/src/events/push.ts
+++ b/src/events/push.ts
@@ -51,7 +51,7 @@ async function handler(
         head_commit: head_commit,
       };
 
-      tracer.startActiveSpan(
+      await tracer.startActiveSpan(
         "app.handler.push.daed_sync_upstream.metadata",
         async (span: Span) => {
           span.setAttributes({
@@ -63,7 +63,7 @@ async function handler(
       );
 
       // 1.2 trigger daed sync-upstream-source workflow
-      const latestRunUrl = tracer.startActiveSpan(
+      const latestRunUrl = await tracer.startActiveSpan(
         "app.handler.push.daed_sync_upstream.trigger_workflow",
         async (span: Span) => {
           span.setAttribute(
@@ -102,7 +102,7 @@ async function handler(
       );
 
       // 1.4 audit event
-      tracer.startActiveSpan(
+      await tracer.startActiveSpan(
         "app.handler.push.daed-sync-upstream.audit_event",
         async (span: Span) => {
           span.setAttribute("functionality", "audit event");
@@ -136,7 +136,7 @@ async function handler(
         head_branch: context.payload.ref.split("/")[2],
       };
 
-      tracer.startActiveSpan(
+      await tracer.startActiveSpan(
         "app.handler.push.daed_sync_upstream.metadata",
         async (span: Span) => {
           span.setAttributes({
@@ -148,7 +148,7 @@ async function handler(
       );
 
       // 1.2 fetch latest sync-upstream workflow run
-      const latestWorkflowRun = tracer.startActiveSpan(
+      const latestWorkflowRun = await tracer.startActiveSpan(
         "app.handler.push.daed_sync_upstream.fetch_latest_workflow_run",
         async (span: Span) => {
           span.setAttribute(
@@ -171,7 +171,7 @@ async function handler(
 
       // 1.3 create a pull_request with head (sync-upstream) and base (main) for daed
       const msg = `⏳ daed (origin/${metadata.default_branch}) is currently out-of-sync to dae-wing (origin/${metadata.default_branch}); changes are proposed by @daebot in actions - ${latestWorkflowRun}`;
-      tracer.startActiveSpan(
+      await tracer.startActiveSpan(
         "app.handler.push.daed_sync_upstream.create_pull_request",
         async (span: Span) => {
           span.setAttribute(
@@ -199,7 +199,7 @@ async function handler(
                     owner: metadata.owner,
                     repo: metadata.repo,
                     issue_number: res.data.number,
-                    labels: ["automated-pr"],
+                    labels: ["automated-pr", "chore"],
                   });
                   span.end();
                 }
@@ -226,7 +226,7 @@ async function handler(
       );
 
       // 1.6 audit event
-      tracer.startActiveSpan(
+      await tracer.startActiveSpan(
         "app.handler.push.daed-sync-upstream.audit_event",
         async (span: Span) => {
           span.setAttribute("functionality", "audit event");

--- a/src/events/push.ts
+++ b/src/events/push.ts
@@ -1,3 +1,4 @@
+import { Span } from "@opentelemetry/api";
 import { Probot, Context } from "probot";
 import {
   Handler,
@@ -6,6 +7,7 @@ import {
   Extension,
   Result,
 } from "../common";
+import { tracer } from "../trace";
 
 export = {
   name: "push",
@@ -20,11 +22,18 @@ async function handler(
   extension: Extension
 ): Promise<Result> {
   const head_commit = JSON.stringify(context.payload?.head_commit);
-  app.log.info(
-    `received a push event: ${head_commit}; ref: ${context.payload.ref}; repo: ${repo.name}`
-  );
-
   const daedSyncBranch = "sync-upstream";
+
+  // instantiate span
+  tracer.startActiveSpan(
+    "app.handler.push.event_logging",
+    async (span: Span) => {
+      const logs = `received a push event: ${head_commit}; ref: ${context.payload.ref}; repo: ${repo.name}`;
+      app.log.info(logs);
+      span.addEvent(logs);
+      span.end();
+    }
+  );
 
   try {
     // case_#1 trigger daed.sync-upstream workflow if new changes are pushed to dae-wing origin/main
@@ -42,41 +51,70 @@ async function handler(
         head_commit: head_commit,
       };
 
+      tracer.startActiveSpan(
+        "app.handler.push.daed_sync_upstream.metadata",
+        async (span: Span) => {
+          span.setAttributes({
+            metadata: JSON.stringify(metadata),
+            case: "trigger daed.sync-upstream workflow if new changes are pushed to dae-wing origin/main",
+          });
+          span.end();
+        }
+      );
+
       // 1.2 trigger daed sync-upstream-source workflow
-      // https://octokit.github.io/rest.js/v18#actions-create-workflow-dispatch
-      // https://docs.github.com/en/rest/actions/workflows?apiVersion=2022-11-28#create-a-workflow-dispatch-event
-      const latestRunUrl = await extension.octokit.actions
-        .createWorkflowDispatch({
-          owner: metadata.owner,
-          repo: metadata.repo,
-          workflow_id: "sync-upstream.yml",
-          ref: metadata.default_branch,
-          inputs: {
-            "wing-head": metadata.default_branch,
-            "wing-sync-message": "chore(sync): upgrade dae-wing",
-            "pr-branch": daedSyncBranch,
-          },
-        })
-        .then(() =>
-          // 1.3 get latest workflow run metadata
-          // https://octokit.github.io/rest.js/v18#actions-list-workflow-runs
-          extension.octokit.actions
-            .listWorkflowRuns({
+      const latestRunUrl = tracer.startActiveSpan(
+        "app.handler.push.daed_sync_upstream.trigger_workflow",
+        async (span: Span) => {
+          span.setAttribute(
+            "functionality",
+            "trigger daed sync-upstream-source workflow"
+          );
+          // https://octokit.github.io/rest.js/v18#actions-create-workflow-dispatch
+          // https://docs.github.com/en/rest/actions/workflows?apiVersion=2022-11-28#create-a-workflow-dispatch-event
+          const result = await extension.octokit.actions
+            .createWorkflowDispatch({
               owner: metadata.owner,
               repo: metadata.repo,
               workflow_id: "sync-upstream.yml",
-              per_page: 1,
+              ref: metadata.default_branch,
+              inputs: {
+                "wing-head": metadata.default_branch,
+                "wing-sync-message": "chore(sync): upgrade dae-wing",
+                "pr-branch": daedSyncBranch,
+              },
             })
-            .then((res) => res.data.workflow_runs[0].html_url)
-        );
+            .then(() =>
+              // 1.3 get latest workflow run metadata
+              // https://octokit.github.io/rest.js/v18#actions-list-workflow-runs
+              extension.octokit.actions
+                .listWorkflowRuns({
+                  owner: metadata.owner,
+                  repo: metadata.repo,
+                  workflow_id: "sync-upstream.yml",
+                  per_page: 1,
+                })
+                .then((res) => res.data.workflow_runs[0].html_url)
+            );
+          span.end();
+          return result;
+        }
+      );
 
       // 1.4 audit event
-      const msg = `🏗️ a new commit was pushed to dae-wing (${metadata.default_branch}); dispatched ${daedSyncBranch} workflow for daed; url: ${latestRunUrl}`;
-      app.log.info(msg);
-
-      await extension.tg.sendMsg(msg, [
-        process.env.TELEGRAM_DAEUNIVERSE_AUDIT_CHANNEL_ID!,
-      ]);
+      tracer.startActiveSpan(
+        "app.handler.push.daed-sync-upstream.audit_event",
+        async (span: Span) => {
+          span.setAttribute("functionality", "audit event");
+          const msg = `🏗️ a new commit was pushed to dae-wing (${metadata.default_branch}); dispatched ${daedSyncBranch} workflow for daed; url: ${latestRunUrl}`;
+          app.log.info(msg);
+          await extension.tg.sendMsg(msg, [
+            process.env.TELEGRAM_DAEUNIVERSE_AUDIT_CHANNEL_ID!,
+          ]);
+          span.addEvent(msg);
+          span.end();
+        }
+      );
     }
   } catch (err) {
     return { result: "Ops something goes wrong.", error: JSON.stringify(err) };
@@ -97,57 +135,108 @@ async function handler(
         default_branch: context.payload.repository.default_branch,
         head_branch: context.payload.ref.split("/")[2],
       };
+
+      tracer.startActiveSpan(
+        "app.handler.push.daed_sync_upstream.metadata",
+        async (span: Span) => {
+          span.setAttributes({
+            metadata: JSON.stringify(metadata),
+            case: "create a pull_request when branch sync-upstream is created and pushed to daed (remote)",
+          });
+          span.end();
+        }
+      );
+
       // 1.2 fetch latest sync-upstream workflow run
-      // https://octokit.github.io/rest.js/v18#actions-list-workflow-runs
-      const latestWorkflowRun = await context.octokit.actions
-        .listWorkflowRuns({
-          owner: metadata.owner,
-          repo: metadata.repo,
-          workflow_id: "sync-upstream.yml",
-          per_page: 1,
-        })
-        .then((res) => res.data.workflow_runs[0]);
+      const latestWorkflowRun = tracer.startActiveSpan(
+        "app.handler.push.daed_sync_upstream.fetch_latest_workflow_run",
+        async (span: Span) => {
+          span.setAttribute(
+            "functionality",
+            "fetch latest sync-upstream workflow run"
+          );
+          // https://octokit.github.io/rest.js/v18#actions-list-workflow-runs
+          const result = await context.octokit.actions
+            .listWorkflowRuns({
+              owner: metadata.owner,
+              repo: metadata.repo,
+              workflow_id: "sync-upstream.yml",
+              per_page: 1,
+            })
+            .then((res) => res.data.workflow_runs[0].html_url);
+          span.end();
+          return result;
+        }
+      );
 
-      // https://github.com/daeuniverse/daed/actions/runs/
       // 1.3 create a pull_request with head (sync-upstream) and base (main) for daed
-      // https://octokit.github.io/rest.js/v18#pulls-create
-      const msg = `⏳ daed (origin/${metadata.default_branch}) is currently out-of-sync to dae-wing (origin/${metadata.default_branch}); changes are proposed by @daebot in actions - ${latestWorkflowRun.html_url}`;
+      const msg = `⏳ daed (origin/${metadata.default_branch}) is currently out-of-sync to dae-wing (origin/${metadata.default_branch}); changes are proposed by @daebot in actions - ${latestWorkflowRun}`;
+      tracer.startActiveSpan(
+        "app.handler.push.daed_sync_upstream.create_pull_request",
+        async (span: Span) => {
+          span.setAttribute(
+            "functionality",
+            "create a pull_request with head (sync-upstream) and base (main) for daed"
+          );
+          // https://octokit.github.io/rest.js/v18#pulls-create
+          await context.octokit.pulls
+            .create({
+              owner: metadata.owner,
+              repo: metadata.repo,
+              head: metadata.head_branch,
+              base: metadata.default_branch,
+              title: "chore(sync): keep upstream source up-to-date",
+              body: msg,
+            })
+            .then((res) => {
+              // 1.4 add labels
+              tracer.startActiveSpan(
+                "app.handler.push.daed_sync_upstream.create_pull_request.add_labels",
+                async (span: Span) => {
+                  span.setAttribute("functionality", "add labels");
+                  // https://octokit.github.io/rest.js/v18#issues-add-labels
+                  context.octokit.issues.addLabels({
+                    owner: metadata.owner,
+                    repo: metadata.repo,
+                    issue_number: res.data.number,
+                    labels: ["automated-pr"],
+                  });
+                  span.end();
+                }
+              );
 
-      await context.octokit.pulls
-        .create({
-          owner: metadata.owner,
-          repo: metadata.repo,
-          head: metadata.head_branch,
-          base: metadata.default_branch,
-          title: "chore(sync): keep upstream source up-to-date",
-          body: msg,
-        })
-        .then((res) => {
-          // 1.4 add labels
-          // https://octokit.github.io/rest.js/v18#issues-add-labels
-          context.octokit.issues.addLabels({
-            owner: metadata.owner,
-            repo: metadata.repo,
-            issue_number: res.data.number,
-            labels: ["automated-pr"],
-          });
-
-          // 1.5 add assignee
-          // https://octokit.github.io/rest.js/v18#issues-add-assignees
-          context.octokit.issues.addAssignees({
-            owner: metadata.owner,
-            repo: metadata.repo,
-            issue_number: res.data.number,
-            assignees: ["daebot"],
-          });
-        });
+              // 1.5 add assignee
+              tracer.startActiveSpan(
+                "app.handler.push.daed_sync_upstream.create_pull_request.add_labels",
+                async (span: Span) => {
+                  span.setAttribute("functionality", "add labels");
+                  // https://octokit.github.io/rest.js/v18#issues-add-assignees
+                  context.octokit.issues.addAssignees({
+                    owner: metadata.owner,
+                    repo: metadata.repo,
+                    issue_number: res.data.number,
+                    assignees: ["daebot"],
+                  });
+                  span.end();
+                }
+              );
+            });
+          span.end();
+        }
+      );
 
       // 1.6 audit event
-      app.log.info(msg);
-
-      await extension.tg.sendMsg(msg, [
-        process.env.TELEGRAM_DAEUNIVERSE_AUDIT_CHANNEL_ID!,
-      ]);
+      tracer.startActiveSpan(
+        "app.handler.push.daed-sync-upstream.audit_event",
+        async (span: Span) => {
+          span.setAttribute("functionality", "audit event");
+          app.log.info(msg);
+          await extension.tg.sendMsg(msg, [
+            process.env.TELEGRAM_DAEUNIVERSE_AUDIT_CHANNEL_ID!,
+          ]);
+          span.end();
+        }
+      );
     }
   } catch (err) {
     return { result: "Ops something goes wrong.", error: JSON.stringify(err) };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
+import run from "./runner";
 import { Span } from "@opentelemetry/api";
 import { Context, Probot } from "probot";
-import run from "./runner";
 import { otel, tracer } from "./trace";
 
 export default (app: Probot) => {
@@ -24,7 +24,7 @@ export default (app: Probot) => {
       "release.published",
     ],
     async (context: Context<any>) => {
-      tracer.startActiveSpan(
+      await tracer.startActiveSpan(
         `app.event.${context.name}`,
         {
           attributes: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,7 @@
-import opentelemetry from "@opentelemetry/api";
 import { Span } from "@opentelemetry/api";
 import { Context, Probot } from "probot";
-import { Run } from "./runner";
-import otel from "./trace";
+import run from "./runner";
+import { otel, tracer } from "./trace";
 
 export default (app: Probot) => {
   app.log(`${process.env.BOT_NAME} app is loaded successfully!`);
@@ -25,10 +24,6 @@ export default (app: Probot) => {
       "release.published",
     ],
     async (context: Context<any>) => {
-      const tracer = opentelemetry.trace.getTracer(
-        process.env.APP_NAME || "dae-bot"
-      );
-      context.id;
       tracer.startActiveSpan(
         `app.event.${context.name}`,
         {
@@ -46,10 +41,13 @@ export default (app: Probot) => {
               action: context.payload.action,
             })
           );
+
           const full_event = context.payload.action
             ? `${context.name}.${context.payload.action}`
             : context.name;
-          const result = await Run(context, app, full_event);
+          span.setAttribute("context.full_event", full_event);
+
+          const result = await run(context, app, full_event);
           result.error ? app.log.error(result) : app.log.info(result);
           span.end();
         }

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -20,8 +20,9 @@ export default async (context: Context<any>, app: Probot, event: string) => {
       };
 
       span.setAttributes({ repo: JSON.stringify(repo) });
+      const result = await module.handler(context, app, repo, extension);
       span.end();
-      return await module.handler(context, app, repo, extension);
+      return result;
     }
   );
 };

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -1,23 +1,27 @@
-import { Repository } from "./common";
+import { Span } from "@opentelemetry/api";
+import { Repository, Result } from "./common";
 import { Handlers } from "./config";
 import { Context, Probot } from "probot";
 import { TelegramClient } from "./telegram";
+import { tracer } from "./trace";
 
-export const Run = async (
-  context: Context<any>,
-  app: Probot,
-  event: string
-) => {
-  const module = Handlers.filter((item) => item.config_key == event)[0];
-  const extension = {
-    octokit: context.octokit,
-    tg: new TelegramClient(),
-  };
+export default async (context: Context<any>, app: Probot, event: string) => {
+  return tracer.startActiveSpan(
+    "app.handler.run",
+    async (span: Span): Promise<Result> => {
+      const module = Handlers.filter((item) => item.config_key == event)[0];
+      const extension = {
+        octokit: context.octokit,
+        tg: new TelegramClient(),
+      };
+      const repo: Repository = {
+        name: context.payload.repository.name,
+        owner: context.payload.organization?.login as string,
+      };
 
-  const repo: Repository = {
-    name: context.payload.repository.name,
-    owner: context.payload.organization?.login as string,
-  };
-
-  return await module.handler(context, app, repo, extension);
+      span.setAttributes({ repo: JSON.stringify(repo) });
+      span.end();
+      return await module.handler(context, app, repo, extension);
+    }
+  );
 };

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -5,24 +5,25 @@ import { Context, Probot } from "probot";
 import { TelegramClient } from "./telegram";
 import { tracer } from "./trace";
 
-export default async (context: Context<any>, app: Probot, event: string) => {
-  return tracer.startActiveSpan(
-    "app.handler.run",
-    async (span: Span): Promise<Result> => {
-      const module = Handlers.filter((item) => item.config_key == event)[0];
-      const extension = {
-        octokit: context.octokit,
-        tg: new TelegramClient(),
-      };
-      const repo: Repository = {
-        name: context.payload.repository.name,
-        owner: context.payload.organization?.login as string,
-      };
+export default async (
+  context: Context<any>,
+  app: Probot,
+  event: string
+): Promise<Result> => {
+  return await tracer.startActiveSpan("app.handler.run", async (span: Span) => {
+    const module = Handlers.filter((item) => item.config_key == event)[0];
+    const extension = {
+      octokit: context.octokit,
+      tg: new TelegramClient(),
+    };
+    const repo: Repository = {
+      name: context.payload.repository.name,
+      owner: context.payload.organization?.login as string,
+    };
 
-      span.setAttributes({ repo: JSON.stringify(repo) });
-      const result = await module.handler(context, app, repo, extension);
-      span.end();
-      return result;
-    }
-  );
+    span.setAttributes({ repo: JSON.stringify(repo) });
+    const result = await module.handler(context, app, repo, extension);
+    span.end();
+    return result;
+  });
 };

--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -7,8 +7,8 @@ export class TelegramClient {
     this.telegram = new Telegram(process.env.TELEGRAM_BOT_TOKEN!);
   }
 
-  sendMsg(msg: string, channels: string[]) {
-    return Promise.all(
+  async sendMsg(msg: string, channels: string[]) {
+    Promise.all(
       channels.map((chat) => {
         this.telegram.sendMessage(chat, msg, {
           parse_mode: "Markdown",

--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -8,13 +8,13 @@ export class TelegramClient {
   }
 
   async sendMsg(msg: string, channels: string[]) {
-    Promise.all(
-      channels.map((chat) => {
+    return await Promise.all(
+      channels.map((chat) =>
         this.telegram.sendMessage(chat, msg, {
           parse_mode: "Markdown",
           disable_web_page_preview: true,
-        });
-      })
+        })
+      )
     );
   }
 }

--- a/src/trace.ts
+++ b/src/trace.ts
@@ -39,8 +39,6 @@ const otel = new sdk.NodeSDK({
   }),
 });
 
-const tracer = opentelemetry.trace.getTracer(
-  process.env.APP_NAME || "dae-bot"
-);
+const tracer = opentelemetry.trace.getTracer(process.env.APP_NAME || "dae-bot");
 
-export {otel, tracer}
+export { otel, tracer };

--- a/src/trace.ts
+++ b/src/trace.ts
@@ -1,15 +1,17 @@
-import * as opentelemetry from "@opentelemetry/sdk-node";
+import opentelemetry from "@opentelemetry/api";
+import * as sdk from "@opentelemetry/sdk-node";
 import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-proto";
 import { OTLPMetricExporter } from "@opentelemetry/exporter-metrics-otlp-proto";
 import { PeriodicExportingMetricReader } from "@opentelemetry/sdk-metrics";
 // import { getNodeAutoInstrumentations } from "@opentelemetry/auto-instrumentations-node";
+//
 
 const { Resource } = require("@opentelemetry/resources");
 const {
   SemanticResourceAttributes,
 } = require("@opentelemetry/semantic-conventions");
 
-export default new opentelemetry.NodeSDK({
+const otel = new sdk.NodeSDK({
   traceExporter: new OTLPTraceExporter({
     url: `${process.env.OTEL_EXPORTER_OTLP_ENDPOINT}/v1/traces`,
     // optional - collection of custom headers to be sent with each request, empty by default
@@ -37,3 +39,7 @@ export default new opentelemetry.NodeSDK({
     "metadata.repo": "dae-bot",
   }),
 });
+
+const tracer = opentelemetry.trace.getTracer(process.env.APP_NAME || "dae-bot");
+
+export { otel, tracer };

--- a/src/trace.ts
+++ b/src/trace.ts
@@ -1,10 +1,9 @@
 import opentelemetry from "@opentelemetry/api";
 import * as sdk from "@opentelemetry/sdk-node";
 import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-proto";
-import { OTLPMetricExporter } from "@opentelemetry/exporter-metrics-otlp-proto";
-import { PeriodicExportingMetricReader } from "@opentelemetry/sdk-metrics";
+// import { OTLPMetricExporter } from "@opentelemetry/exporter-metrics-otlp-proto";
+// import { PeriodicExportingMetricReader } from "@opentelemetry/sdk-metrics";
 // import { getNodeAutoInstrumentations } from "@opentelemetry/auto-instrumentations-node";
-//
 
 const { Resource } = require("@opentelemetry/resources");
 const {
@@ -17,16 +16,16 @@ const otel = new sdk.NodeSDK({
     // optional - collection of custom headers to be sent with each request, empty by default
     headers: {},
   }),
-  metricReader: new PeriodicExportingMetricReader({
-    exporter: new OTLPMetricExporter({
-      url: `${process.env.OTEL_EXPORTER_OTLP_ENDPOINT}/v1/metrics`,
-      // an optional object containing custom headers to be sent with each request
-      headers: {},
-    }),
-    exportIntervalMillis: 30 * 1000, // 30s
-  }),
-  // instrumentations: [getNodeAutoInstrumentations()],
+  // metricReader: new PeriodicExportingMetricReader({
+  //   exporter: new OTLPMetricExporter({
+  //     url: `${process.env.OTEL_EXPORTER_OTLP_ENDPOINT}/v1/metrics`,
+  //     // an optional object containing custom headers to be sent with each request
+  //     headers: {},
+  //   }),
+  //   exportIntervalMillis: 30 * 1000, // 30s
+  // }),
   // Optionally register automatic instrumentation libraries
+  // instrumentations: [getNodeAutoInstrumentations()],
   instrumentations: [],
   resource: new Resource({
     [SemanticResourceAttributes.SERVICE_NAME]: process.env.APP_NAME,
@@ -40,6 +39,8 @@ const otel = new sdk.NodeSDK({
   }),
 });
 
-const tracer = opentelemetry.trace.getTracer(process.env.APP_NAME || "dae-bot");
+const tracer = opentelemetry.trace.getTracer(
+  process.env.APP_NAME || "dae-bot"
+);
 
-export { otel, tracer };
+export {otel, tracer}


### PR DESCRIPTION
## Summary

Instrument codebase for `push` event. Also, include fix for `telegram.sendMessage`.
## Test Result

<img width="640" alt="image" src="https://github.com/daeuniverse/dae-bot/assets/31861128/966a61b9-2a66-4f52-b1c6-5d80af79e746">

<img width="640" alt="image" src="https://github.com/daeuniverse/dae-bot/assets/31861128/87f6a257-e082-4cbd-acaa-d3bdfb8c88c3">

## Changelogs

- refactor(trace): instantiate tracer in ./trace
- feat(trace): create child runner span
- patch(runner): refine return logic
- feat(trace): instrument push event handler
- patch: apply minior patches
- mock: mod telegram handler
- patch(telegram): use async sendMsg
- patch(telegram): update promise.all default return
- refactor: use async handler
- patch(telegram): update promise.all default return
- refactor(trace): demise autoInstructment and metricsExporter
- refactor(handler/push): use async for all injected spans

