### PR TITLE
feat(handler/star.created): add tracing support

### DIFF
--- a/src/events/push.ts
+++ b/src/events/push.ts
@@ -108,6 +108,7 @@ async function handler(
           span.setAttribute("functionality", "audit event");
           const msg = `🏗️ a new commit was pushed to dae-wing (${metadata.default_branch}); dispatched ${daedSyncBranch} workflow for daed; url: ${latestRunUrl}`;
           app.log.info(msg);
+          span.addEvent(msg);
           await extension.tg.sendMsg(msg, [
             process.env.TELEGRAM_DAEUNIVERSE_AUDIT_CHANNEL_ID!,
           ]);
@@ -231,6 +232,7 @@ async function handler(
         async (span: Span) => {
           span.setAttribute("functionality", "audit event");
           app.log.info(msg);
+          span.addEvent(msg);
           await extension.tg.sendMsg(msg, [
             process.env.TELEGRAM_DAEUNIVERSE_AUDIT_CHANNEL_ID!,
           ]);
@@ -238,8 +240,8 @@ async function handler(
         }
       );
     }
-  } catch (err) {
-    return { result: "Ops something goes wrong.", error: JSON.stringify(err) };
+  } catch (err: any) {
+    return { result: "Ops something goes wrong.", error: err };
   }
 
   return { result: "ok!" };

--- a/src/events/star.created.ts
+++ b/src/events/star.created.ts
@@ -1,4 +1,5 @@
 import kv from "@vercel/kv";
+import { Span } from "@opentelemetry/api";
 import { Probot, Context } from "probot";
 import {
   Handler,
@@ -7,6 +8,7 @@ import {
   Extension,
   Result,
 } from "../common";
+import { tracer } from "../trace";
 
 export = {
   name: "star.created",
@@ -15,36 +17,83 @@ export = {
 } as HandlerModule;
 
 async function handler(
-  context: Context<any>,
+  context: Context<"star.created">,
   app: Probot,
   repo: Repository,
   extension: Extension
 ): Promise<Result> {
-  app.log.info(`received a star.created event: ${JSON.stringify(repo)}`);
-
-  const actualStars = await kv.get<string>(`stars.${repo.name}`);
-  if (!actualStars) {
-    return {
-      result: "Ops something goes wrong.",
-      error: JSON.stringify("key does not exist"),
-    };
-  }
-
-  const payload = context.payload.repository;
+  // instantiate span
+  await tracer.startActiveSpan(
+    "app.handler.star.created.event_logging",
+    async (span: Span) => {
+      const logs = `received a star.created event: ${JSON.stringify(repo)}`;
+      app.log.info(logs);
+      span.addEvent(logs);
+      span.end();
+    }
+  );
 
   try {
-    if (payload.stargazers_count > Number.parseInt(actualStars)) {
-      await kv.set(`stars.${repo.name}`, payload.stargazers_count);
-      const msg = `⭐ Repo: ${payload.name} received a new star from [@${context.payload.sender.login}](${context.payload.sender.html_url})! Total stars: ${payload.stargazers_count}`;
-      app.log.info(msg);
+    // 1.1 construct metadata from payload
+    const metadata = {
+      repo: repo.name,
+      owner: repo.owner,
+      author: context.payload.sender.login,
+      default_branch: context.payload.repository.default_branch,
+      stargazers_count: context.payload.repository.stargazers_count,
+    };
 
-      // 1.2 audit event
-      await extension.tg.sendMsg(msg, [
-        process.env.TELEGRAM_DAEUNIVERSE_AUDIT_CHANNEL_ID!,
-      ]);
+    // 1.2 get current stargazers_count from kv
+    const actualStars = await tracer.startActiveSpan(
+      "app.handler.star.created.get_current_stargazers_count)",
+      async (span: Span) => {
+        span.setAttribute(
+          "functionality",
+          "get current stargazers_count from kv"
+        );
+        const result = await kv.get<string>(`stars.${repo.name}`);
+        span.end();
+        return result;
+      }
+    );
+    if (!actualStars) {
+      return {
+        result: "Ops something goes wrong.",
+        error: "key does not exist",
+      };
     }
-  } catch (err) {
-    return { result: "Ops something goes wrong.", error: JSON.stringify(err) };
+
+    if (metadata.stargazers_count > Number.parseInt(actualStars)) {
+      // 1.3 store current stargazers_count to kv
+      await tracer.startActiveSpan(
+        "app.handler.star.created.increment_stargazers_count",
+        async (span: Span) => {
+          span.setAttribute(
+            "functionality",
+            "store current stargazers_count to kv"
+          );
+          await kv.set(`stars.${repo.name}`, metadata.stargazers_count);
+          span.end();
+        }
+      );
+
+      // 1.4 audit event
+      await tracer.startActiveSpan(
+        "app.handler.star.created.audit_event",
+        async (span: Span) => {
+          span.setAttribute("functionality", "audit event");
+          const msg = `⭐ Repo: ${metadata.repo} received a new star from [@${context.payload.sender.login}](${context.payload.sender.html_url})! Total stars: ${metadata.stargazers_count}`;
+          app.log.info(msg);
+          await extension.tg.sendMsg(msg, [
+            process.env.TELEGRAM_DAEUNIVERSE_AUDIT_CHANNEL_ID!,
+          ]);
+          span.addEvent(msg);
+          span.end();
+        }
+      );
+    }
+  } catch (err: any) {
+    return { result: "Ops something goes wrong.", error: err };
   }
 
   return { result: "ok!" };

--- a/src/events/star.created.ts
+++ b/src/events/star.created.ts
@@ -17,7 +17,7 @@ export = {
 } as HandlerModule;
 
 async function handler(
-  context: Context<"star.created">,
+  context: Context<any>,
   app: Probot,
   repo: Repository,
   extension: Extension


### PR DESCRIPTION
## Summary

Add tracing support for `star.created` handler.

## Test Result

<img width="1285" alt="image" src="https://github.com/daeuniverse/dae-bot/assets/31861128/e3c4b4bb-28a8-497e-90e5-04d338d7b72c">

<img width="1662" alt="image" src="https://github.com/daeuniverse/dae-bot/assets/31861128/dd196dc5-5a68-4b39-bbe0-c3db55846f14">

## Changelogs

- refactor(handler/star.created): add tracing support
- fix(handler/push): populate audit log in span