### PR TITLE
refactor(handler/pr.opened): add tracing support

### DIFF
--- a/mock/template/span.ts
+++ b/mock/template/span.ts
@@ -1,0 +1,14 @@
+import opentelemetry, { Span } from "@opentelemetry/api";
+
+const tracer = opentelemetry.trace.getTracer(process.env.APP_NAME || "dae-bot");
+
+const span = async () => {
+  await tracer.startActiveSpan(
+    "app.handler.star.created.event_logging",
+    { attributes: { metadata: "some metadata" } },
+    async (span: Span) => {
+      span.addEvent("something");
+      span.end();
+    }
+  );
+};

--- a/src/events/pull_request.opened.ts
+++ b/src/events/pull_request.opened.ts
@@ -1,3 +1,4 @@
+import { Span, SpanStatusCode } from "@opentelemetry/api";
 import { Probot, Context } from "probot";
 import {
   Handler,
@@ -6,6 +7,7 @@ import {
   Extension,
   Result,
 } from "../common";
+import { tracer } from "../trace";
 
 export = {
   name: "pull_request.opened",
@@ -34,11 +36,6 @@ async function handler(
       html_url: context.payload.pull_request.html_url,
     },
   };
-
-  app.log.info(
-    `received a pull_request.opened event: ${JSON.stringify(metadata)}`
-  );
-
   const defaultLables = [
     "fix",
     "feat",
@@ -56,123 +53,305 @@ async function handler(
 
   const strictLabels = defaultLables.slice(0, -4);
 
+  await tracer.startActiveSpan(
+    "app.handler.pull_request.opened.event_logging",
+    async (span: Span) => {
+      const msg = `received a pull_request.opened event: ${JSON.stringify(
+        metadata
+      )}`;
+      app.log.info(msg);
+      span.addEvent(msg);
+      span.end();
+    }
+  );
+
   // case_#1: automatically assign assignee if not present
-  try {
-    // 1.1 assign pull_request author to be the default assignee
-    // https://octokit.github.io/rest.js/v18#issues-add-assignees
-    const author = metadata.pull_request.author.includes("bot")
-      ? "daebot"
-      : metadata.pull_request.author;
-    await extension.octokit.issues.addAssignees({
-      owner: metadata.owner,
-      repo: metadata.repo,
-      issue_number: metadata.pull_request.number,
-      assignees: [author],
-    });
+  await tracer.startActiveSpan(
+    "app.handler.pull_request.opened.assign_default_assignee",
+    {
+      attributes: {
+        case: "assign pull_request author to be the default assignee",
+      },
+    },
+    async (span: Span) => {
+      try {
+        // https://octokit.github.io/rest.js/v18#issues-add-assignees
+        const author = metadata.pull_request.author.includes("bot")
+          ? "daebot"
+          : metadata.pull_request.author;
 
-    // 1.2 audit event
-    const msg = `👷 PR - [#${metadata.pull_request.number}: ${metadata.pull_request.title}](${metadata.pull_request.html_url}) is raised in ${metadata.repo}; assign @${author} as the default assignee.`;
-
-    app.log.info(msg);
-
-    await extension.tg.sendMsg(msg, [
-      process.env.TELEGRAM_DAEUNIVERSE_AUDIT_CHANNEL_ID!,
-    ]);
-  } catch (err: any) {
-    return { result: "Ops something goes wrong.", error: err };
-  }
-
-  // case_#2: automatically assign label if not present, default label should align with "kind" as part of the pr title
-  try {
-    // 1.1 automatically add label(s) to pull_request
-    // https://octokit.github.io/rest.js/v18#issues-list-labels-on-issue
-    const prOpenedLabels = await extension.octokit.issues
-      .listLabelsOnIssue({
-        owner: metadata.owner,
-        repo: metadata.repo,
-        issue_number: metadata.pull_request.number,
-      })
-      .then((res) => res.data);
-
-    if (prOpenedLabels.length == 0) {
-      let labels = defaultLables
-        .filter((label: string) => {
-          const re = /^(?<type>\w+)(\((?<scope>.+)\))?:/;
-          const { type } = metadata.pull_request.title.match(re)?.groups!;
-          return type === label;
-        })
-        .map((item) => {
-          if (item == "feat") item = "feature";
-          if (item == "docs" || item == "doc") item = "documentation";
-          return item;
-        });
-
-      if (labels.length > 0) {
-        // check if "not-yet-tested" is eligible to be added
-        if (
-          strictLabels.filter((label) =>
-            metadata.pull_request.title.startsWith(label)
-          ).length > 0
-        ) {
-          // add "not-yet-tested label"
-          labels = [...labels, "not-yet-tested"];
-
-          if (["dae", "daed"].includes(metadata.repo)) {
-            // request review from qa team
-            // https://octokit.github.io/rest.js/v18#pulls-create-review-request
-            await extension.octokit.rest.pulls.requestReviewers({
+        // 1.1 assign pull_request author to be the default assignee
+        await tracer.startActiveSpan(
+          "app.handler.pull_request.opened.assign_default_assignee.add_assignee",
+          {
+            attributes: {
+              functionality: "add default assignee",
+            },
+          },
+          async (span: Span) => {
+            await extension.octokit.issues.addAssignees({
               owner: metadata.owner,
               repo: metadata.repo,
-              pull_number: metadata.pull_request.number,
-              team_reviewers: ["qa"],
+              issue_number: metadata.pull_request.number,
+              assignees: [author],
             });
+            span.addEvent(`add default assignee: ${author}`);
+            span.end();
           }
-        }
+        );
 
-        // https://octokit.github.io/rest.js/v18#issues-add-labels
-        await extension.octokit.issues.addLabels({
-          owner: metadata.owner,
-          repo: metadata.repo,
-          issue_number: metadata.pull_request.number,
-          labels: labels,
-        });
+        await tracer.startActiveSpan(
+          "app.handler.pull_request.opened.assign_default_assignee.audit_event",
+          {
+            attributes: {
+              functionality: "audit event",
+            },
+          },
+          async (span: Span) => {
+            // 1.2 audit event
+            const msg = `👷 PR - [#${metadata.pull_request.number}: ${metadata.pull_request.title}](${metadata.pull_request.html_url}) is raised in ${metadata.repo}; assign @${author} as the default assignee.`;
 
-        // 1.2 audit event
-        const msg = `🏷 PR - [#${metadata.pull_request.number}](${
-          metadata.pull_request.html_url
-        }) in ${metadata.repo} is missing labels; added ${JSON.stringify(
-          labels
-        )}.`;
-
-        app.log.info(msg);
-
-        await extension.tg.sendMsg(msg, [
-          process.env.TELEGRAM_DAEUNIVERSE_AUDIT_CHANNEL_ID!,
-        ]);
+            app.log.info(msg);
+            span.addEvent(msg);
+            await extension.tg.sendMsg(msg, [
+              process.env.TELEGRAM_DAEUNIVERSE_AUDIT_CHANNEL_ID!,
+            ]);
+            span.end();
+          }
+        );
+      } catch (err: any) {
+        span.recordException(err);
+        span.setStatus({ code: SpanStatusCode.ERROR });
       }
+
+      span.end();
     }
-  } catch (err: any) {
-    return { result: "Ops something goes wrong.", error: err };
-  }
+  );
+
+  // case_#2: automatically assign label if not present, default label should align with "kind" as part of the pr title
+  await tracer.startActiveSpan(
+    "app.handler.pull_request.opened.assign_labels",
+    {
+      attributes: {
+        case: "automatically assign label if not present, default label should align with kind as part of the pr title",
+        condition: "label.not_present == true",
+      },
+    },
+    async (span: Span) => {
+      try {
+        // automatically add label(s) to pull_request
+        await tracer.startActiveSpan(
+          "app.handler.pull_request.opened.assign_labels.add_labels",
+          {
+            attributes: {
+              functionality: "automatically add label(s) to pull_request",
+            },
+          },
+          async (span: Span) => {
+            // 1.1 list current assign labels
+            const prOpenedLabels = await tracer.startActiveSpan(
+              "app.handler.pull_request.opened.assign_labels.list_active_labels",
+              {
+                attributes: {
+                  functionality: "check current assigned labels",
+                },
+              },
+              async (span: Span) => {
+                // https://octokit.github.io/rest.js/v18#issues-list-labels-on-issue
+                const result = await extension.octokit.issues
+                  .listLabelsOnIssue({
+                    owner: metadata.owner,
+                    repo: metadata.repo,
+                    issue_number: metadata.pull_request.number,
+                  })
+                  .then((res) => res.data);
+                span.addEvent(JSON.stringify(result));
+                span.end();
+                return result;
+              }
+            );
+
+            await tracer.startActiveSpan(
+              "app.handler.pull_request.opened.assign_labels.add_labels",
+              {
+                attributes: {
+                  functionality: "add labels",
+                  condition: "prOpenedLabels.length == 0",
+                },
+              },
+              async (span: Span) => {
+                if (prOpenedLabels.length == 0) {
+                  let labels = defaultLables
+                    .filter((label: string) => {
+                      const re = /^(?<type>\w+)(\((?<scope>.+)\))?:/;
+                      const { type } =
+                        metadata.pull_request.title.match(re)?.groups!;
+                      return type === label;
+                    })
+                    .map((item) => {
+                      if (item == "feat") item = "feature";
+                      if (item == "docs" || item == "doc")
+                        item = "documentation";
+                      return item;
+                    });
+
+                  span.addEvent(
+                    `label retrieved from pr.title: ${JSON.stringify(labels)}`
+                  );
+
+                  if (labels.length > 0) {
+                    // check if "not-yet-tested" is eligible to be added
+                    await tracer.startActiveSpan(
+                      "app.handler.pull_request.opened.assign_labels.add_labels.not_yet_tested",
+                      {
+                        attributes: {
+                          functionality: "add not-yet-tested label",
+                          condition: "strictLabels.included == true",
+                        },
+                      },
+                      async (span: Span) => {
+                        if (
+                          strictLabels.filter((label) =>
+                            metadata.pull_request.title.startsWith(label)
+                          ).length > 0
+                        ) {
+                          // add "not-yet-tested label"
+                          labels = [...labels, "not-yet-tested"];
+
+                          span.addEvent(
+                            `label not-yet-tested has been added; current labels: ${JSON.stringify(
+                              labels
+                            )}`
+                          );
+
+                          if (["dae", "daed"].includes(metadata.repo)) {
+                            // request review from qa team
+                            await tracer.startActiveSpan(
+                              "app.handler.pull_request.opened.assign_labels.add_labels.not_yet_tested.request_qa_review",
+                              {
+                                attributes: {
+                                  functionality: "request review from qa team",
+                                  condition: "ONLY applicable in [dae,daed]",
+                                },
+                              },
+                              async (span: Span) => {
+                                // https://octokit.github.io/rest.js/v18#pulls-create-review-request
+                                await extension.octokit.rest.pulls.requestReviewers(
+                                  {
+                                    owner: metadata.owner,
+                                    repo: metadata.repo,
+                                    pull_number: metadata.pull_request.number,
+                                    team_reviewers: ["qa"],
+                                  }
+                                );
+
+                                span.end();
+                              }
+                            );
+                          }
+                        }
+
+                        span.end();
+                      }
+                    );
+
+                    // 1.2 add labels
+                    await tracer.startActiveSpan(
+                      "app.handler.pull_request.opened.assign_labels.add_labels.add",
+                      {
+                        attributes: {
+                          functionality: "add labels",
+                        },
+                      },
+                      async (span: Span) => {
+                        span.addEvent(`labels to be added: ${labels}`);
+                        // https://octokit.github.io/rest.js/v18#issues-add-labels
+                        await extension.octokit.issues.addLabels({
+                          owner: metadata.owner,
+                          repo: metadata.repo,
+                          issue_number: metadata.pull_request.number,
+                          labels: labels,
+                        });
+
+                        span.end();
+                      }
+                    );
+
+                    // 1.3 audit event
+                    await tracer.startActiveSpan(
+                      "app.handler.pull_request.opened.assign_labels.add_labels.audit_event",
+                      {
+                        attributes: {
+                          functionality: "audit event",
+                        },
+                      },
+                      async (span: Span) => {
+                        const msg = `🏷 PR - [#${
+                          metadata.pull_request.number
+                        }](${metadata.pull_request.html_url}) in ${
+                          metadata.repo
+                        } is missing labels; added ${JSON.stringify(labels)}.`;
+
+                        app.log.info(msg);
+
+                        await extension.tg.sendMsg(msg, [
+                          process.env.TELEGRAM_DAEUNIVERSE_AUDIT_CHANNEL_ID!,
+                        ]);
+
+                        span.end();
+                      }
+                    );
+                  }
+                }
+
+                span.end();
+              }
+            );
+
+            span.end();
+          }
+        );
+      } catch (err: any) {
+        span.recordException(err);
+        span.setStatus({ code: SpanStatusCode.ERROR });
+      }
+
+      span.end();
+    }
+  );
 
   // case_#3: assign daebot as one of the reviewers
-  try {
-    if (
-      defaultLables.filter((label: string) =>
-        metadata.pull_request.title.startsWith(label)
-      ).length > 0
-    ) {
-      // 1.1 assign daebot as one of the reviewers
-      // https://octokit.github.io/rest.js/v18#pulls-request-reviewers
-      await extension.octokit.pulls.requestReviewers({
-        repo: metadata.repo,
-        owner: metadata.owner,
-        pull_number: metadata.pull_request.number,
-        reviewers: ["dae-bot[bot]"],
-      });
-    }
-  } catch (err: any) {
-    return { result: "Ops something goes wrong.", error: err };
+  if (
+    strictLabels.filter((label: string) =>
+      metadata.pull_request.title.startsWith(label)
+    ).length > 0
+  ) {
+    await tracer.startActiveSpan(
+      "app.handler.pull_request.opened.assign_dae_bot_as_reviewers",
+      {
+        attributes: {
+          case: "assign daebot as one of the reviewers",
+        },
+      },
+      async (span: Span) => {
+        try {
+          // 1.1 assign daebot as one of the reviewers
+          // https://octokit.github.io/rest.js/v18#pulls-request-reviewers
+          await extension.octokit.pulls.requestReviewers({
+            repo: metadata.repo,
+            owner: metadata.owner,
+            pull_number: metadata.pull_request.number,
+            reviewers: ["dae-bot[bot]"],
+          });
+        } catch (err: any) {
+          app.log(err);
+          span.recordException(err);
+          span.setStatus({ code: SpanStatusCode.ERROR });
+        }
+
+        span.end();
+      }
+    );
   }
 
   return { result: "ok!" };

--- a/src/events/push.ts
+++ b/src/events/push.ts
@@ -40,7 +40,7 @@ async function handler(
     context.payload.ref == "refs/heads/main" &&
     context.payload.repository.name == "dae-wing"
   ) {
-    return await tracer.startActiveSpan(
+    await tracer.startActiveSpan(
       "app.handler.push.daed_sync_upstream",
       {
         attributes: {
@@ -122,16 +122,12 @@ async function handler(
             }
           );
         } catch (err: any) {
+          app.log.error(err);
           span.recordException(err);
           span.setStatus({ code: SpanStatusCode.ERROR });
-          return {
-            result: "Ops something goes wrong.",
-            error: err,
-          };
         }
 
         span.end();
-        return { result: "ok!" };
       }
     );
   }
@@ -142,7 +138,7 @@ async function handler(
     context.payload.repository.name == "daed" &&
     context.payload.ref.split("/")[2] == daedSyncBranch
   ) {
-    return await tracer.startActiveSpan(
+    await tracer.startActiveSpan(
       "app.handler.push.daed_sync_upstream",
       async (span: Span) => {
         span.setAttributes({
@@ -272,13 +268,12 @@ async function handler(
             }
           );
         } catch (err: any) {
+          app.log.error(err);
           span.recordException(err);
           span.setStatus({ code: SpanStatusCode.ERROR });
-          return { result: "Ops something goes wrong.", error: err };
         }
 
         span.end();
-        return { result: "ok!" };
       }
     );
   }

--- a/src/events/star.created.ts
+++ b/src/events/star.created.ts
@@ -68,10 +68,7 @@ async function handler(
           }
         );
         if (!actualStars) {
-          return {
-            result: "Ops something goes wrong.",
-            error: "key does not exist",
-          };
+          throw Error("key does not exist");
         }
 
         if (metadata.stargazers_count > Number.parseInt(actualStars)) {
@@ -105,13 +102,12 @@ async function handler(
           );
         }
       } catch (err: any) {
+        app.log.error(err);
         span.recordException(err);
         span.setStatus({ code: SpanStatusCode.ERROR });
-        return { result: "Ops something goes wrong.", error: err };
       }
 
       span.end();
-      return { result: "ok!" };
     }
   );
 


### PR DESCRIPTION
## Summary

Add tracing support for `pr.opened` handler.

## Changelogs

- refactor: rework default error handling
- refactor(handler/pr.opened): add tracing support
- fixture(mock): add span template

## Test Result

<img width="1241" alt="image" src="https://github.com/daeuniverse/dae-bot/assets/31861128/9d2affcf-e4ad-4576-855c-73610046cb5a">

<img width="1658" alt="image" src="https://github.com/daeuniverse/dae-bot/assets/31861128/3c96999b-cf95-4cca-9586-b4543bdcecb1">
