### PR TITLE
feat(sync_upstream): add auto-merge support

### DIFF
--- a/mock/delete_remote_branch_test.ts
+++ b/mock/delete_remote_branch_test.ts
@@ -1,0 +1,26 @@
+import { Octokit } from "octokit";
+// Create a personal access token at https://github.com/settings/tokens/new?scopes=repo
+const octokit = new Octokit({ auth: process.env.GITHUB_TOKEN });
+
+// Compare: https://docs.github.com/en/rest/reference/users#get-the-authenticated-user
+const main = async () => {
+  try {
+    const {
+      data: { login },
+    } = await octokit.rest.users.getAuthenticated();
+    console.log("Hello, %s", login);
+
+    // delete an existing remote branch
+    // https://octokit.github.io/rest.js/v18#git-delete-ref
+    // https://docs.github.com/en/rest/git#delete-a-reference
+    await octokit.rest.git.deleteRef({
+      owner: "daeuniverse",
+      repo: "daed-1",
+      ref: `heads/sync-upstream`,
+    });
+  } catch (err: any) {
+    console.log(err);
+  }
+};
+
+main();

--- a/src/events/pull_request.opened.ts
+++ b/src/events/pull_request.opened.ts
@@ -307,38 +307,38 @@ async function handler(
   );
 
   // case_#3: assign daebot as one of the reviewers
-  if (
-    strictLabels.filter((label: string) =>
-      metadata.pull_request.title.startsWith(label)
-    ).length > 0
-  ) {
-    await tracer.startActiveSpan(
-      "app.handler.pull_request.opened.assign_dae_bot_as_reviewers",
-      {
-        attributes: {
-          case: "assign daebot as one of the reviewers",
-        },
-      },
-      async (span: Span) => {
-        try {
-          // 1.1 assign daebot as one of the reviewers
-          // https://octokit.github.io/rest.js/v18#pulls-request-reviewers
-          await extension.octokit.pulls.requestReviewers({
-            repo: metadata.repo,
-            owner: metadata.owner,
-            pull_number: metadata.pull_request.number,
-            reviewers: ["dae-bot[bot]"],
-          });
-        } catch (err: any) {
-          app.log(err);
-          span.recordException(err);
-          span.setStatus({ code: SpanStatusCode.ERROR });
-        }
+  // if (
+  //   strictLabels.filter((label: string) =>
+  //     metadata.pull_request.title.startsWith(label)
+  //   ).length > 0
+  // ) {
+  //   await tracer.startActiveSpan(
+  //     "app.handler.pull_request.opened.assign_dae_bot_as_reviewers",
+  //     {
+  //       attributes: {
+  //         case: "assign daebot as one of the reviewers",
+  //       },
+  //     },
+  //     async (span: Span) => {
+  //       try {
+  //         // 1.1 assign daebot as one of the reviewers
+  //         // https://octokit.github.io/rest.js/v18#pulls-request-reviewers
+  //         await extension.octokit.pulls.requestReviewers({
+  //           repo: metadata.repo,
+  //           owner: metadata.owner,
+  //           pull_number: metadata.pull_request.number,
+  //           reviewers: ["dae-bot[bot]"],
+  //         });
+  //       } catch (err: any) {
+  //         app.log(err);
+  //         span.recordException(err);
+  //         span.setStatus({ code: SpanStatusCode.ERROR });
+  //       }
 
-        span.end();
-      }
-    );
-  }
+  //       span.end();
+  //     }
+  //   );
+  // }
 
   return { result: "ok!" };
 }

--- a/src/events/push.ts
+++ b/src/events/push.ts
@@ -290,15 +290,20 @@ async function handler(
 
           // 1.5 delete sync-upstream branch
           await tracer.startActiveSpan(
-            "app.handler.push.daed_sync_upstream.create_pr.audit_event",
-            { attributes: { functionality: "delete sync-upstream branch" } },
+            "app.handler.push.daed_sync_upstream.create_pr.delete_remote_branch",
+            {
+              attributes: {
+                functionality: "delete sync-upstream branch",
+                branch: `heads/${daedSyncBranch}`,
+              },
+            },
             async (span: Span) => {
               // https://octokit.github.io/rest.js/v18#git-delete-ref
               // https://docs.github.com/en/rest/git#delete-a-reference
               await extension.octokit.rest.git.deleteRef({
                 owner: "daeuniverse",
                 repo: "daed",
-                ref: `heads/sync-upstream`,
+                ref: `heads/${daedSyncBranch}`,
               });
               span.end();
             }


### PR DESCRIPTION
## Summary

Implement #34 - Add `auto-merge` support.

## Expected Outcome

Sync-upstream PR merges to main automatically without manual intervention.

## Test Result

Trigger sync workflow

<img width="1721" alt="image" src="https://github.com/daeuniverse/dae-bot/assets/31861128/aec26917-55e3-48d0-8023-bdb0372b461f">

<img width="963" alt="image" src="https://github.com/daeuniverse/dae-bot/assets/31861128/1b18e907-237d-4354-8c7b-a37823318b05">

<img width="1667" alt="image" src="https://github.com/daeuniverse/dae-bot/assets/31861128/ea160ab1-eecb-4c8b-9913-a3e056384330">
