### PR TITLE
fix(default_labels): re-arrange order

### DIFF
--- a/src/constant.ts
+++ b/src/constant.ts
@@ -8,12 +8,12 @@ export const defaultLables = [
   "patch",
   "ci",
   "optimize",
-  "chore",
   "refactor",
   "style",
   "doc",
   "docs",
   "fixture",
+  "chore",
 ];
 
-export const strictLabels = defaultLables.slice(0, -4);
+export const strictLabels = defaultLables.slice(0, -5);


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

Do not add `not-yet-tested` label when PR title is set to `chore: ***` in the first place.

### Checklist

- [ ] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full changelogs

- fix(default_labels): re-arrange order

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->

NA

### Test Result

<!--- Attach any test results -->

NA