### PR TITLE
feat(sync-upstream): include dae-wing as a sync candidate

### DIFF
--- a/mock/pr_merge_test.ts
+++ b/mock/pr_merge_test.ts
@@ -1,0 +1,26 @@
+import { Octokit } from "octokit";
+// Create a personal access token at https://github.com/settings/tokens/new?scopes=repo
+const octokit = new Octokit({ auth: process.env.GITHUB_TOKEN });
+
+// Compare: https://docs.github.com/en/rest/reference/users#get-the-authenticated-user
+const main = async () => {
+  try {
+    const {
+      data: { login },
+    } = await octokit.rest.users.getAuthenticated();
+    console.log("Hello, %s", login);
+
+    // create pull_request_review request
+    // https://octokit.github.io/rest.js/v18#pulls-merge
+    await octokit.rest.pulls.merge({
+      repo: "dae-wing",
+      owner: "daeuniverse",
+      pull_number: 64,
+      merge_method: "squash",
+    });
+  } catch (err: any) {
+    console.log(err);
+  }
+};
+
+main();

--- a/mock/ref_delete_test.ts
+++ b/mock/ref_delete_test.ts
@@ -1,0 +1,25 @@
+import { Octokit } from "octokit";
+// Create a personal access token at https://github.com/settings/tokens/new?scopes=repo
+const octokit = new Octokit({ auth: process.env.GITHUB_TOKEN });
+
+// Compare: https://docs.github.com/en/rest/reference/users#get-the-authenticated-user
+const main = async () => {
+  try {
+    const {
+      data: { login },
+    } = await octokit.rest.users.getAuthenticated();
+    console.log("Hello, %s", login);
+
+    // https://octokit.github.io/rest.js/v18#git-delete-ref
+    // https://docs.github.com/en/rest/git#delete-a-reference
+    await octokit.rest.git.deleteRef({
+      repo: "dae-wing",
+      owner: "daeuniverse",
+      ref: "heads/sync-upstream",
+    });
+  } catch (err: any) {
+    console.log(err);
+  }
+};
+
+main();

--- a/src/events/push.ts
+++ b/src/events/push.ts
@@ -304,29 +304,7 @@ async function handler(
             }
           );
 
-          // 1.5 delete sync-upstream branch
-          await tracer.startActiveSpan(
-            `app.handler.push.${repo.name}_sync_upstream.create_pr.delete_remote_branch`,
-            {
-              attributes: {
-                functionality: `delete ${syncBranch} branch`,
-                branch: `heads/${syncBranch}`,
-              },
-            },
-            async (span: Span) => {
-              // https://octokit.github.io/rest.js/v18#git-delete-ref
-              // https://docs.github.com/en/rest/git#delete-a-reference
-              await extension.octokit.rest.git.deleteRef({
-                repo: metadata.repo,
-                owner: metadata.owner,
-                ref: `heads/${syncBranch}`,
-              });
-
-              span.end();
-            }
-          );
-
-          // 1.6 audit event
+          // 1.5 audit event
           await tracer.startActiveSpan(
             `app.handler.push.${repo.name}_sync_upstream.create_pr.audit_event`,
             { attributes: { functionality: "audit event" } },


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

Add support to raise a PR automatically if `sync-upstream` is pushed to remote.

### Checklist

- [x] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full changelogs

- feat(sync-upstream): make sync candidate dynamic
- fixture(mock): add ref_delete_test.ts
- fixture(mock): add pr_merge_test.ts

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->

Closes https://github.com/daeuniverse/dae-wing/issues/60

### Test Result

<!--- Attach test result here. -->

<img width="1171" alt="image" src="https://github.com/daeuniverse/dae-bot/assets/31861128/912158f8-5017-43f6-b737-5247a3623ea1">
