### PR TITLE
fix(handler/push/sync-upstream): demise checking sync-branch creation

### DIFF
--- a/src/events/push.ts
+++ b/src/events/push.ts
@@ -141,7 +141,6 @@ async function handler(
 
   // case_#2 create a pull_request when branch sync-upstream is created and pushed to syncTarget (remote)
   if (
-    context.payload.before == "0000000000000000000000000000000000000000" &&
     ["dae-wing", "daed"].includes(context.payload.repository.name) &&
     context.payload.ref.split("/")[2] == syncBranch
   ) {


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

Demise checking `sync-branch` creation for `push/sync-upstream` event.

### Checklist

- [x] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full changelogs

- hotfix(handler/push/sync-upstream): demise checking sync-branch creation

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->

NA

### Test Result

<!--- Attach test result here. -->

NA
