### PR TITLE
chore: prepare for sync-upstream event chain

### DIFF
--- a/mock/update_sync_pr_test.ts
+++ b/mock/update_sync_pr_test.ts
@@ -1,0 +1,69 @@
+import { Octokit } from "octokit";
+// Create a personal access token at https://github.com/settings/tokens/new?scopes=repo
+const octokit = new Octokit({ auth: process.env.GITHUB_TOKEN });
+
+// Compare: https://docs.github.com/en/rest/reference/users#get-the-authenticated-user
+const main = async () => {
+  try {
+    const {
+      data: { login },
+    } = await octokit.rest.users.getAuthenticated();
+    console.log("Hello, %s", login);
+
+    // 1.1 get pull_request with a given commit
+    // https://octokit.github.io/rest.js/v18#pulls-get
+    const spliter =
+      "<!--- Why is this change required? What problem does it solve? -->";
+
+    const pr = await octokit.rest.pulls
+      .get({
+        owner: "daeuniverse",
+        repo: "dae",
+        pull_number: 225,
+      })
+      .then((res) => res.data);
+
+    const context = `${pr.body?.split("### Checklist")[0].split(spliter)[1]}
+      `.trim();
+
+    // 1.2 update dae-wing sync pr description
+    // https://octokit.github.io/rest.js/v18#pulls-update
+    await octokit.rest.pulls
+      .list({
+        owner: "daeuniverse",
+        repo: "dae-wing",
+      })
+      .then((res) => {
+        const syncPR = res.data.filter((pr) =>
+          pr.title.startsWith("chore(sync)")
+        )[0];
+
+        // construct new body
+        const newBody = `
+${syncPR.body}
+
+### #${pr.number} - ${pr.title}
+
+Ref: <${pr.html_url}>
+
+Context:
+
+${context}
+
+---
+`.trim();
+
+        // update PR description
+        octokit.rest.pulls.update({
+          owner: "daeuniverse",
+          repo: "dae-wing",
+          pull_number: syncPR.number,
+          body: newBody,
+        });
+      });
+  } catch (err: any) {
+    console.log(err);
+  }
+};
+
+main();

--- a/src/events/pull_request.closed.ts
+++ b/src/events/pull_request.closed.ts
@@ -120,6 +120,7 @@ async function handler(
 
   // case_#2: create a release tag when release_branch is merged; ONLY with release:auto tag
   if (
+    ["dae", "daed"].includes(metadata.repo) &&
     metadata.pull_request.merged &&
     metadata.pull_request.ref.startsWith("release-v") &&
     metadata.pull_request.labels.includes("release:auto") &&

--- a/src/events/push.ts
+++ b/src/events/push.ts
@@ -201,7 +201,11 @@ async function handler(
           );
 
           // 1.3 create a pull_request with head (sync-upstream) and base (main) for daed
-          const msg = `⏳ ${repo.name} (origin/${metadata.default_branch}) is currently out-of-sync to ${syncSource} (origin/${metadata.default_branch}); changes are proposed by @daebot in actions - ${latestWorkflowRun}`;
+          const msg = `
+⏳ ${repo.name} (origin/${metadata.default_branch}) is currently out-of-sync to ${syncSource} (origin/${metadata.default_branch}); changes are proposed by @daebot in actions - ${latestWorkflowRun}
+
+## Changelogs
+`.trim();
 
           const pr = await tracer.startActiveSpan(
             `app.handler.push.${repo.name}_sync_upstream.create_pr.create`,


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

Prepare for sync-upstream event chain as part of #73.

### Checklist

- [x] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full changelogs

- fixture(mock): add update_sync_pr_test
- patch(push/sync-upstream): update default pr description
- patch(pr.closed): ONLY [dae,daed] can trigger release workflow

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->

NA

### Test Result

<!--- Attach test result here. -->

NA