### PR TITLE
patch(gateway): add additional check_run event filter

### DIFF
--- a/src/gateway.ts
+++ b/src/gateway.ts
@@ -29,15 +29,27 @@ export class APIGateway {
 
     switch (this.event) {
       case "check_run.completed":
-        accepted =
+        if (
           this.metadata.check_run.name.includes("dae-bot") &&
+          this.metadata.check_run.name.includes("build-passed") &&
           this.metadata.check_run.conclusion === "success" &&
-          this.metadata.check_run.pull_requests.length > 0;
+          this.metadata.check_run.pull_requests.length > 0
+        )
+          accepted = true;
+
+        if (
+          this.metadata.check_run.name.includes("dae-bot") &&
+          this.metadata.check_run.conclusion === "failure" &&
+          this.metadata.check_run.pull_requests.length > 0
+        )
+          accepted = true;
         break;
       case "workflow_run.completed":
-        accepted =
+        if (
           ["dae-wing"].includes(this.repo.name) &&
-          this.metadata.workflow_run.conclusion === "success";
+          this.metadata.workflow_run.conclusion === "success"
+        )
+          accepted = true;
         break;
       default:
         break;

--- a/src/gateway.ts
+++ b/src/gateway.ts
@@ -34,22 +34,25 @@ export class APIGateway {
           this.metadata.check_run.name.includes("build-passed") &&
           this.metadata.check_run.conclusion === "success" &&
           this.metadata.check_run.pull_requests.length > 0
-        )
+        ) {
           accepted = true;
+        }
 
         if (
           this.metadata.check_run.name.includes("dae-bot") &&
           this.metadata.check_run.conclusion === "failure" &&
           this.metadata.check_run.pull_requests.length > 0
-        )
+        ) {
           accepted = true;
+        }
         break;
       case "workflow_run.completed":
         if (
           ["dae-wing"].includes(this.repo.name) &&
           this.metadata.workflow_run.conclusion === "success"
-        )
+        ) {
           accepted = true;
+        }
         break;
       default:
         break;


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

ONLY accept `check_run.completed` event for `build-passed` check_run.

### Checklist

- [x] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full changelogs

- patch(gateway): add additional check_run event filter

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->

NA

### Test Result

<!--- Attach test result here. -->

NA
