### PR TITLE
feat/refactor(pr.opened): parse multiple labels

### DIFF
--- a/mock/label_filter_test.ts
+++ b/mock/label_filter_test.ts
@@ -13,18 +13,27 @@ const defaultLables = [
   "fixture",
 ];
 
+const overwriteLabels = (input: string[]): string[] => {
+  return input.map((item) => {
+    if (item == "feat") item = "feature";
+    if (item == "docs" || item == "doc") item = "documentation";
+    return item;
+  });
+};
+
 const testLabelRegex = (input: string): string[] => {
-  return defaultLables
-    .filter((label: string) => {
-      const re = /^(?<type>\w+)(\((?<scope>.+)\))?:/;
-      const { type } = input.match(re)?.groups!;
-      return type === label;
-    })
-    .map((item) => {
-      if (item == "feat") item = "feature";
-      if (item == "docs" || item == "doc") item = "documentation";
-      return item;
-    });
+  // const re = /^(?<type>\w+)(\/\w+)*(\((?<scope>.+)\))?:/;
+  const re = /^(?<type>\w+(\/\w+)*)(\((?<scope>.+)\))?:/;
+  const { type } = input.match(re)?.groups!;
+  const labels = type.split("/");
+
+  return labels.length > 1
+    ? overwriteLabels(
+        labels.map(
+          (label: string) => defaultLables.filter((x: string) => label === x)[0]
+        )
+      )
+    : overwriteLabels(defaultLables.filter((x: string) => type === x));
 };
 
 const prTitle1 = "fixture(context): some title";
@@ -32,9 +41,11 @@ const prTitle2 = "fix(context): some title";
 const prTitle3 = "docs(context): some title";
 const prTitle4 = "docu(context): some title";
 const prTitle5 = "feat: display daed version in header";
+const prTitle6 = "feat/fix/ci(context): some title;";
 
 console.log(testLabelRegex(prTitle1));
 console.log(testLabelRegex(prTitle2));
 console.log(testLabelRegex(prTitle3));
 console.log(testLabelRegex(prTitle4));
 console.log(testLabelRegex(prTitle5));
+console.log(testLabelRegex(prTitle6));

--- a/src/constant.ts
+++ b/src/constant.ts
@@ -6,6 +6,7 @@ export const defaultLables = [
   "feat",
   "feature",
   "patch",
+  "hotfix",
   "ci",
   "optimize",
   "refactor",


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

Rework label assignments to match the multiple labels.

Expected: [feature, fix, ci] from "feat/fix/ci(context): some title"

### Checklist

- [x] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full changelogs

- fixture(mock): rework label_filter_test
- refactor(pr.opened): rework label assignment
- feat(constant): add hotfix to defaultLabels

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->

NA

### Test Result

<!--- Attach test result here. -->

<img width="640" alt="image" src="https://github.com/daeuniverse/dae-bot/assets/31861128/8d8bed72-b6b1-404a-b9a9-7f4e3063c2a1">

<img width="1131" alt="image" src="https://github.com/daeuniverse/dae-bot/assets/31861128/201af33c-4b5e-4e2b-ae4f-d97234930a4c">

<img width="1329" alt="image" src="https://github.com/daeuniverse/dae-bot/assets/31861128/e16026ae-3c83-4b8b-8ebc-1febc0bbc333">

<img width="1660" alt="image" src="https://github.com/daeuniverse/dae-bot/assets/31861128/067fe82d-8b79-44a6-9bdb-244b69c487e6">
