### PR TITLE
refactor: persist releaseCandidates in constant.ts

### DIFF
--- a/src/constant.ts
+++ b/src/constant.ts
@@ -17,4 +17,6 @@ export const defaultLables = [
   "chore",
 ];
 
+export const releaseCandidates = ["dae", "daed", "juicity"];
+
 export const strictLabels = defaultLables.slice(0, -5);

--- a/src/events/issue_comment.created.ts
+++ b/src/events/issue_comment.created.ts
@@ -7,6 +7,7 @@ import {
   Result,
 } from "../common";
 import { Buffer } from "buffer";
+import { releaseCandidates } from "../constant";
 import prettier from "prettier";
 
 const Encode = (data: string): string =>
@@ -53,7 +54,7 @@ async function handler(
     // case_#1: dump release changelogs to release branch (e.g. release-v0.1.0)
     // 1.1 patch new changelogs into CHANGELOGS.md with regex
     if (
-      ["dae", "daed", "juicity", "juicity-1"].includes(metadata.repo) &&
+      releaseCandidates.includes(metadata.repo) &&
       metadata.comment.body.includes("-bot") &&
       metadata.comment.body.includes("release-") &&
       metadata.issue.state == "closed" &&


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

Persist release candidates in constant.ts

### Checklist

- [x] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full changelogs

- refactor: persist releaseCandidates in constant.ts

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->

NA

### Test Result

<!--- Attach test result here. -->

NA
