### PR TITLE
patch(pr.closed): add repo.name metadata to notification msg

### DIFF
--- a/src/events/pull_request.closed.ts
+++ b/src/events/pull_request.closed.ts
@@ -251,7 +251,7 @@ async function handler(
             "app.handler.pull_request.release_automation.merged.audit_event",
             { attributes: { functionality: "audit event" } },
             async (span: Span) => {
-              const msg = `🌌 PR - [#${metadata.pull_request.number}: ${metadata.pull_request.title}](${metadata.pull_request.html_url}) associated with ${metadata.pull_request.ref} has been merged; created and pushed a new release tag ${tag}; release build is now kicked off! just chill, we are getting there 💪; workflow run: ${workflowRunUrl}.`;
+              const msg = `🌌 PR - [#${metadata.pull_request.number}: ${metadata.pull_request.title}](${metadata.pull_request.html_url}) associated with ${metadata.pull_request.ref} in ${metadata.repo} has been merged; created and pushed a new release tag ${tag}; release build is now kicked off! just chill, we are getting there 💪; workflow run: ${workflowRunUrl}.`;
               app.log.info(msg);
               span.addEvent(msg);
               await extension.tg.sendMsg(msg, [


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

Add `repo.name` metadata to notification msg

### Checklist

- [x] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full changelogs

- patch(pr.closed): add repo.name metadata to notification msg

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->

NA

### Test Result

<!--- Attach test result here. -->

NA