### PR TITLE
patch: deprecate all relevant handlers for daed

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -9,7 +9,7 @@ import IssueCloseHandler from "./events/issues.closed";
 import IssueOpenHandler from "./events/issues.opened";
 import IssueCommentCreateHandler from "./events/issue_comment.created";
 import PushHandler from "./events/push";
-import CheckRunCompleteHandler from "./events/check_run.completed";
+// import CheckRunCompleteHandler from "./events/check_run.completed";
 import WorkflowRunCompleteHandler from "./events/workflow_run.completed";
 
 export interface Configuration {
@@ -27,7 +27,7 @@ export const Handlers: HandlerModule[] = [
   IssueOpenHandler,
   IssueCommentCreateHandler,
   PushHandler,
-  CheckRunCompleteHandler,
+  //  CheckRunCompleteHandler,
   WorkflowRunCompleteHandler,
 ];
 

--- a/src/events/pull_request.closed.ts
+++ b/src/events/pull_request.closed.ts
@@ -126,7 +126,7 @@ async function handler(
 
   // case_#2: create a release tag when release_branch is merged; ONLY with release:auto tag
   if (
-    ["dae", "daed", "juicity"].includes(metadata.repo) &&
+    ["dae", "juicity"].includes(metadata.repo) &&
     metadata.pull_request.merged &&
     metadata.pull_request.ref.startsWith("release-v") &&
     metadata.pull_request.labels.includes("release:auto") &&


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

As the title suggests. Since daed is about to adopt a different set of implementation, no need to use release gate and pr-upstream-sync.

### Checklist

- [x] The Pull Request has been fully tested

### Full Changelogs

- patch: deprecate all relevant handlers for daed

### Issue Reference

<!--- If it fixes an open issue, please link to the issue here. -->

Closes #_[issue number]_

### Test Result

<!--- Attach test result here. -->
